### PR TITLE
JSON_FORECAST_URL changed

### DIFF
--- a/hamsclientfork/client.py
+++ b/hamsclientfork/client.py
@@ -20,7 +20,7 @@ class StationType(str, Enum):
 _LOGGER = logging.getLogger(__name__)
 
 MS_BASE_URL = "https://www.meteosuisse.admin.ch"
-JSON_FORECAST_URL = "https://app-prod-ws.meteoswiss-app.ch/v1/forecast?plz={}00&graph=false&warning=true"
+JSON_FORECAST_URL = "https://app-prod-ws.meteoswiss-app.ch/v1/forecast?plz={}00&warning=true"
 MS_SEARCH_URL = "https://www.meteosuisse.admin.ch/home/actualite/infos.html?ort={}&pageIndex=0&tab=search_tab"
 CURRENT_CONDITION_URL = (
     "https://data.geo.admin.ch/ch.meteoschweiz.messwerte-aktuell/VQHA80.csv"


### PR DESCRIPTION
If you remove "graph=false" from the URL, we get a lot of more data.
The jsonobj then also contains a weeks worth of temperature and precipitation forecasts (max, min and mean for every hour, 168 values). For the precipitation there's even min, max and mean for the next 100 data points every 10 min.
This data can then be used elsewhere, e.g. the Home Assistant